### PR TITLE
modified time picker spinner to show hours before minutes

### DIFF
--- a/lib/src/components/time_picker_spinner.dart
+++ b/lib/src/components/time_picker_spinner.dart
@@ -275,6 +275,7 @@ class _TimePickerSpinnerState extends State<TimePickerSpinner> {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisAlignment: MainAxisAlignment.center,
+      textDirection: TextDirection.ltr,
       children: contents,
     );
   }


### PR DESCRIPTION
I am using this package in my application. Since my default local language is Arabic, which is right-to-left. All widgets' order is consequently changed & reversed to be right to left. In Arabic, you still set the hours before the minutes, hours should be on the left, followed by the minutes. This PR addressed this issue by enforcing that hours be displayed first before minutes.