### PR TITLE
Fix https://github.com/alanchan-dev/OmniDateTimePicker/issues/64

### DIFF
--- a/lib/src/components/time_picker_spinner/bloc/time_picker_spinner_bloc.dart
+++ b/lib/src/components/time_picker_spinner/bloc/time_picker_spinner_bloc.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:omni_datetime_picker/src/components/time_picker_spinner/bloc/utils.dart';
 
@@ -78,8 +78,14 @@ class TimePickerSpinnerBloc
     required List<String> hours,
     required DateTime now,
   }) {
-    if (now.hour >= 12 && !is24HourMode) {
-      return hours.indexWhere((e) => e == (now.hour - 12).toString());
+    if (!is24HourMode) {
+      if (now.hour >= 12) {
+        return hours.indexWhere((e) =>
+            e == (TimeOfDay.fromDateTime(now).hourOfPeriod - 12).toString());
+      } else {
+        return hours.indexWhere(
+            (e) => e == TimeOfDay.fromDateTime(now).hourOfPeriod.toString());
+      }
     }
 
     return hours.indexWhere((e) => e == now.hour.toString());
@@ -117,6 +123,9 @@ class TimePickerSpinnerBloc
     final List<String> hours = List.generate(
       is24HourMode ? 24 : 12,
       (index) {
+        if (!is24HourMode && index == 0) {
+          return '12';
+        }
         return '$index';
       },
     );

--- a/lib/src/components/time_picker_spinner/time_picker_spinner.dart
+++ b/lib/src/components/time_picker_spinner/time_picker_spinner.dart
@@ -100,9 +100,8 @@ class TimePickerSpinner extends StatelessWidget {
                                   ? 12
                                   : 0;
 
-                          datetimeBloc.add(UpdateHour(
-                              hour:
-                                  int.parse(state.hours[index]) + hourOffset));
+                          datetimeBloc
+                              .add(UpdateHour(hour: index + hourOffset));
                         } else {
                           datetimeBloc.add(
                               UpdateHour(hour: int.parse(state.hours[index])));


### PR DESCRIPTION
- replaced '0' with '12' in hours list when not in 24-hour mode
- used hours index instead of value to update hour when not in 24-hour mode
- used TimeOfDay.hourOfPeriod to get initialHourIndex when not in 24-hour mode