### PR TITLE
Fixed incorrect hour conversion for PM times in `_getInitialHourIndex()`

### DIFF
--- a/lib/src/components/time_picker_spinner/bloc/time_picker_spinner_bloc.dart
+++ b/lib/src/components/time_picker_spinner/bloc/time_picker_spinner_bloc.dart
@@ -79,13 +79,12 @@ class TimePickerSpinnerBloc
     required DateTime now,
   }) {
     if (!is24HourMode) {
-      if (now.hour >= 12) {
-        return hours.indexWhere((e) =>
-            e == (TimeOfDay.fromDateTime(now).hourOfPeriod - 12).toString());
-      } else {
-        return hours.indexWhere(
-            (e) => e == TimeOfDay.fromDateTime(now).hourOfPeriod.toString());
-      }
+      int hourOfPeriod = TimeOfDay.fromDateTime(now).hourOfPeriod;
+
+      // Ensure 12 AM is displayed as '12' and not '0'
+      String hourString = hourOfPeriod == 0 ? '12' : hourOfPeriod.toString();
+
+      return hours.indexWhere((e) => e == hourString);
     }
 
     return hours.indexWhere((e) => e == now.hour.toString());


### PR DESCRIPTION
This PR addresses a bug in TimePickerSpinnerBloc where hours were not correctly initialized when using 12-hour mode, particularly for PM times.

Issue & Fix
Bug: PM hours were not correctly mapped to the hour list, and 12 AM was incorrectly handled as "0" instead of "12".
Fix:
Used TimeOfDay.fromDateTime(now).hourOfPeriod directly without unnecessary subtraction for PM times.
Ensured that "12 AM" is correctly represented as "12", preventing incorrect indexing.
Improved lookup logic to reliably fetch the correct hour index.

Testing
Tested with the following cases to ensure correct initialization:
✅ 11:00 AM → correctly maps to "11"
✅ 12:00 PM → correctly maps to "12"
✅ 1:00 PM → correctly maps to "1"
✅ 11:59 PM → correctly maps to "11"
✅ 12:00 AM → correctly maps to "12"